### PR TITLE
C++ OpenMP solution for B

### DIFF
--- a/contest/b_nom_de_groupe/sol/b_nom_de_groupe.cpp
+++ b/contest/b_nom_de_groupe/sol/b_nom_de_groupe.cpp
@@ -1,0 +1,49 @@
+// Solution by Louis Sugy
+
+#include <iostream>
+#include <string>
+
+int score(std::string name) {
+  int l = name.size();
+  bool bonus = false;
+  const char *name_array = name.c_str();
+
+  int nv = 0, nc = 0;
+#pragma omp parallel for reduction(+ : nv, nc) schedule(guided)
+  for (int i = 0; i < l; i++) {
+    char c = name_array[i];
+    if (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'y')
+      nv++;
+    else
+      nc++;
+  }
+  int s = 2 * nv - nc;
+
+#pragma omp parallel for reduction(|| : bonus) schedule(guided)
+  for (int i = 0; i < l; i++) {
+    bonus = bonus || (i < l - 2 && name_array[i] == 'k' &&
+                      name_array[i + 1] == 'e' && name_array[i + 2] == 'r');
+  }
+
+  if (bonus)
+    s += 5;
+
+  if (s > 0) {
+    bool palindrome = true;
+#pragma omp parallel for reduction(&& : palindrome) schedule(guided)
+    for (int i = 0; i < l / 2; i++) {
+      palindrome = palindrome && name_array[i] == name_array[l - 1 - i];
+    }
+    if (palindrome)
+      s *= 2;
+  }
+
+  return s;
+}
+
+int main(int argc, char **argv) {
+  std::string name;
+  std::cin >> name;
+  std::cout << score(name) << std::endl;
+  return 0;
+}

--- a/contest/b_nom_de_groupe/sol/b_nom_de_groupe.cpp
+++ b/contest/b_nom_de_groupe/sol/b_nom_de_groupe.cpp
@@ -3,26 +3,23 @@
 #include <iostream>
 #include <string>
 
-int score(std::string name) {
-  int l = name.size();
+int score(std::string& name) {
+  const int l = name.size();
   bool bonus = false;
-  const char *name_array = name.c_str();
 
-  int nv = 0, nc = 0;
-#pragma omp parallel for reduction(+ : nv, nc) schedule(guided)
+  int nv = 0;
+#pragma omp parallel for reduction(+ : nv) schedule(guided)
   for (int i = 0; i < l; i++) {
-    char c = name_array[i];
+    char c = name[i];
     if (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'y')
       nv++;
-    else
-      nc++;
   }
-  int s = 2 * nv - nc;
+  int s = 3 * nv - l;
 
 #pragma omp parallel for reduction(|| : bonus) schedule(guided)
   for (int i = 0; i < l; i++) {
-    bonus = bonus || (i < l - 2 && name_array[i] == 'k' &&
-                      name_array[i + 1] == 'e' && name_array[i + 2] == 'r');
+    bonus = bonus || (i < l - 2 && name[i] == 'k' &&
+                      name[i + 1] == 'e' && name[i + 2] == 'r');
   }
 
   if (bonus)
@@ -32,7 +29,7 @@ int score(std::string name) {
     bool palindrome = true;
 #pragma omp parallel for reduction(&& : palindrome) schedule(guided)
     for (int i = 0; i < l / 2; i++) {
-      palindrome = palindrome && name_array[i] == name_array[l - 1 - i];
+      palindrome = palindrome && name[i] == name[l - 1 - i];
     }
     if (palindrome)
       s *= 2;


### PR DESCRIPTION
Actually it's not faster for the given test cases because they're too small to compensate the overhead of creating the thread pool.

I created my own input data with a length of 10^7 to benchmark, here are the results (yeah, the speedups aren't huge because the performance is dominated by reading the input file...):

![b_openmp](https://user-images.githubusercontent.com/17441062/97091535-cd1cd600-163c-11eb-8362-c2dda6693d1e.png)

For reference, the Python solution is about 10 times slower than the sequential C++ one (i.e my solution compiled without `-fopenmp`).